### PR TITLE
Ignore muted messages in Telegram unread count

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -95,7 +95,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://web.telegram.org/'
 			,type: 'messaging'
 			,titleBlink: true
-			,js_unread: 'function checkUnread(){var e=document.getElementsByClassName("im_dialog_badge badge"),t=0;for(i=0;i<e.length;i++)t+=parseInt(e[i].innerHTML.trim());updateBadge(t)}function updateBadge(e){document.title="("+e+") RamboxService"}setInterval(checkUnread,3000);'
+			,js_unread: 'function checkUnread(){var e=document.getElementsByClassName("im_dialog_badge badge"),t=0;for(i=0;i<e.length;i++)if(!Array.prototype.includes.call(e[i].className.split(" "), "im_dialog_badge_muted")) { t+=parseInt(e[i].innerHTML.trim()) };updateBadge(t)}function updateBadge(e){document.title="("+e+") RamboxService"}setInterval(checkUnread,3000);'
 		},
 		{
 			 id: 'wechat'


### PR DESCRIPTION
This filters muted messages from unread count in Telegram service.

Currently, the Telegram service computes unread count based on class `im_dialog_badge badge`.
This includes the count of muted conversations which add an additional class `im_dialog_badge_muted` to the badge.

In order to ignore the count of these muted conversations, the list of elements is filtered for not having the class `im_dialog_badge_muted`.